### PR TITLE
Basic RTC functions

### DIFF
--- a/HardwareTests/src/layer1/I2C/obc_i2c_rb.c
+++ b/HardwareTests/src/layer1/I2C/obc_i2c_rb.c
@@ -1,17 +1,20 @@
+#include <Chip.h>
+
 #include "obc_i2c_rb.h"
 
-static inline void __enable_irq() { __asm volatile ("cpsie i"); }
-static inline void __disable_irq() { __asm volatile ("cpsid i"); }
-
-void taskDISABLE_INTERRUPTS() {
-	// in peg here is some ASM inline code called from RTOS
-	__disable_irq();
-}
-
-void taskENABLE_INTERRUPTS() {
-	// in peg here is some ASM inline code called from RTOS
-	__enable_irq();
-}
+//
+//static inline void __enable_irq() { __asm volatile ("cpsie i"); }
+//static inline void __disable_irq() { __asm volatile ("cpsid i"); }
+//
+//void taskDISABLE_INTERRUPTS() {
+//	// in peg here is some ASM inline code called from RTOS
+//	__disable_irq();
+//}
+//
+//void taskENABLE_INTERRUPTS() {
+//	// in peg here is some ASM inline code called from RTOS
+//	__enable_irq();
+//}
 
 void I2C_RB_init(I2C_RB *rb)
 {
@@ -22,7 +25,7 @@ void I2C_RB_init(I2C_RB *rb)
 
 void I2C_RB_put(I2C_RB *rb, void* daten)
 {
-	taskDISABLE_INTERRUPTS();
+	__disable_irq();
 	rb->buffer[rb->end] = daten;
 	rb->end = (rb->end + 1) & (I2C_RB_Size - 1);
 
@@ -32,7 +35,7 @@ void I2C_RB_put(I2C_RB *rb, void* daten)
 //		obc_status_extended.i2c_rb_overflow = 1;
 		rb->start = (rb->start + 1) & (I2C_RB_Size - 1);
 	}
-	taskENABLE_INTERRUPTS();
+	__enable_irq();
 }
 
 uint8_t I2C_RB_full(I2C_RB *rb)
@@ -57,10 +60,10 @@ void* I2C_RB_read(I2C_RB *rb)
 {
 	void *daten;
 
-	taskDISABLE_INTERRUPTS();
+	__disable_irq();
 	daten = rb->buffer[rb->start];
 	rb->start = (rb->start + 1) & (I2C_RB_Size - 1);
-	taskENABLE_INTERRUPTS();
+	__enable_irq();
 
 	return daten;
 }

--- a/HardwareTests/src/mod/crc/obc_checksums.c
+++ b/HardwareTests/src/mod/crc/obc_checksums.c
@@ -1,0 +1,122 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+
+#include "obc_checksums.h"
+
+
+//void c_CRC8(char data, uint8_t *checksum);
+
+/* Update CRC8 Checksum */
+void c_CRC8(char data, uint8_t *checksum)
+{
+    uint8_t i;
+    *checksum ^= data;
+
+    for (i = 0; i < 8; ++i)
+    {
+        *checksum = (*checksum << 1) ^ ((*checksum & 0x80) ? 0x07 : 0x00);
+    }
+}
+
+/* Compute CRC8 (binary String) */
+uint8_t CRC8(uint8_t* str, size_t length)
+{
+    uint8_t checksum = 0;
+
+    for (; length--; c_CRC8(*str++, &checksum))
+        ;
+
+    return checksum;
+}
+
+uint8_t odd_parity_calc(uint8_t val)
+{
+    uint8_t parity = (val >> 7);
+    int i;
+    for (i = 6; i >= 0; i--)
+    {
+        parity = ((parity & 0b00000001) ^ ((val >> i) & 0b00000001));
+    }
+
+    /* ODD parity: True if sum of all ones in data byte is even */
+    return 0x01 & (parity ^ 0b00000001);
+}
+
+uint8_t gps_checksum_calc(char *str)
+{
+    uint8_t checksum = 0;
+    uint32_t i;
+
+    char * ptr = memchr(str, '*', 80);
+
+    if (ptr == NULL)
+    {
+        /* No valid GPS string */
+        return 0;
+    }
+
+    uint8_t len = ptr - str;
+
+    for (i = 1; i < len; i++) /* 80 Bytes is the maximum length of a GPS string including \r\n; skip $ */
+    {
+        if ((str[i] == '*'))
+        {
+            /* Checksum is calculated of bytes between $ and *. */
+            break;
+        }
+
+        checksum = checksum ^ str[i];
+    }
+
+    return checksum;
+}
+
+uint32_t crc32(uint8_t *data, uint32_t len)
+{
+    unsigned int i;
+    int j;
+    unsigned int byte, crc, mask;
+
+    i = 0;
+    crc = 0xFFFFFFFF;
+
+    while (i < len)
+    {
+        byte = data[i];            // Get next byte.
+        crc = crc ^ byte;
+        for (j = 7; j >= 0; j--)
+        {    // Do eight times.
+            mask = -(crc & 1);
+            crc = (crc >> 1) ^ (0xEDB88320 & mask);
+        }
+        i = i + 1;
+    }
+    return ~crc;
+}
+
+uint16_t CRC16(const uint8_t* data_p, uint16_t length){
+    uint8_t x;
+    uint16_t crc = 0xFFFF;
+
+    while (length--){
+        x = crc >> 8 ^ *data_p++;
+        x ^= x>>4;
+        crc = (crc << 8) ^ ((uint16_t)(x << 12)) ^ ((uint16_t)(x <<5)) ^ ((uint16_t)x);
+    }
+    return crc;
+}
+
+uint16_t Fletcher16(uint8_t* data, int len){
+    uint16_t sum1 = 0;
+    uint16_t sum2 = 0;
+    int index;
+    for(index=0;index<len;++index){
+        sum1 = (sum1 + data[index]) % 255;
+	sum2 = (sum2 + sum1) % 255;
+    }
+    return (sum2 << 8) | sum1;
+}
+
+

--- a/HardwareTests/src/mod/crc/obc_checksums.h
+++ b/HardwareTests/src/mod/crc/obc_checksums.h
@@ -1,0 +1,14 @@
+/*
+ * obc_checksums.h
+ *
+ *  Created on: 29.12.2019
+ *      Author: Robert
+ */
+
+#ifndef MOD_CRC_OBC_CHECKSUMS_H_
+#define MOD_CRC_OBC_CHECKSUMS_H_
+
+uint8_t CRC8(uint8_t* str, size_t length);
+uint32_t crc32(uint8_t *data, uint32_t len);
+
+#endif /* MOD_CRC_OBC_CHECKSUMS_H_ */

--- a/HardwareTests/src/mod/main.c
+++ b/HardwareTests/src/mod/main.c
@@ -24,12 +24,12 @@
 void MainInit() {
 	printf("Hello %s HardwareTest. Bootmode: %s [%d]\n", BOARD_SHORT, ClimbGetBootmodeStr(), ClimbGetBootmode());
 	TimInit();
-	CliInit();
 	RtcInit();
 	ThrInit();
 	EepromInit();
 	FlashInit();
 	MramInit();
+	CliInit();
 }
 
 // Poll all Modules from Main loop

--- a/HardwareTests/src/mod/main.c
+++ b/HardwareTests/src/mod/main.c
@@ -25,7 +25,7 @@ void MainInit() {
 	printf("Hello %s HardwareTest. Bootmode: %s [%d]\n", BOARD_SHORT, ClimbGetBootmodeStr(), ClimbGetBootmode());
 	TimInit();
 	CliInit();
-	rtc_init();
+	RtcInit();
 	ThrInit();
 	EepromInit();
 	FlashInit();

--- a/HardwareTests/src/mod/main.c
+++ b/HardwareTests/src/mod/main.c
@@ -44,6 +44,7 @@ void MainMain() {
 		ClimbLedToggle(0);
 		// Call module mains with 'tick - requirement'
 		EepromMain();
+		RtcMain();			// At this moment we only track day changes here so Tick time is enough.
 	}
 
 //  Test timer delay function....

--- a/HardwareTests/src/mod/main.c
+++ b/HardwareTests/src/mod/main.c
@@ -13,9 +13,11 @@
 #include "cli/cli.h"
 #include "thr/thruster.h"
 #include "tim/timer.h"
+#include "tim/obc_rtc.h"
 #include "mem/eeprom.h"
 #include "mem/flash.h"
 #include "mem/mram.h"
+
 
 
 // Call all Module Inits
@@ -23,6 +25,7 @@ void MainInit() {
 	printf("Hello %s HardwareTest. Bootmode: %s [%d]\n", BOARD_SHORT, ClimbGetBootmodeStr(), ClimbGetBootmode());
 	TimInit();
 	CliInit();
+	rtc_init();
 	ThrInit();
 	EepromInit();
 	FlashInit();

--- a/HardwareTests/src/mod/mem/eeprom.c
+++ b/HardwareTests/src/mod/mem/eeprom.c
@@ -14,6 +14,7 @@
 #include "../main.h"
 #include "../cli/cli.h"
 #include "../tim/timer.h"
+#include "../crc/obc_checksums.h"
 
 
 // module variables
@@ -40,7 +41,6 @@ void ReadStatusCmd(int argc, char *argv[]);
 void ReadPageCmd(int argc, char *argv[]);
 void ReadPageFinished(eeprom_page_t *page);
 void ReadStatusReceived(eeprom_page_t *page);
-uint32_t crc32(uint8_t *data, uint32_t len);
 
 void EepromInit() {
 	// Register module Commands
@@ -236,30 +236,6 @@ void EepromMain() {
 			readInProgress = false;
 		}
 	}
-}
-
-
-uint32_t crc32(uint8_t *data, uint32_t len)
-{
-    unsigned int i;
-    int j;
-    unsigned int byte, crc, mask;
-
-    i = 0;
-    crc = 0xFFFFFFFF;
-
-    while (i < len)
-    {
-        byte = data[i];            // Get next byte.
-        crc = crc ^ byte;
-        for (j = 7; j >= 0; j--)
-        {    // Do eight times.
-            mask = -(crc & 1);
-            crc = (crc >> 1) ^ (0xEDB88320 & mask);
-        }
-        i = i + 1;
-    }
-    return ~crc;
 }
 
 

--- a/HardwareTests/src/mod/tim/obc_rtc.c
+++ b/HardwareTests/src/mod/tim/obc_rtc.c
@@ -1,0 +1,534 @@
+#include <stdio.h>
+#include <time.h>
+#include <chip.h>
+
+/* Other includes */
+#include "obc_rtc.h"
+#include "../crc/obc_checksums.h"
+
+typedef struct obc_status_s
+{
+	unsigned int last_reset_source1 :1; /* Bit 0 *//* (source1 source2) POR: 0b00, EXTR: 0b01, WDTR: 0b10; BODR: 0b11 */
+	unsigned int last_reset_source2 :1; /* Bit 1 */
+	unsigned int obc_powersave :1; /* Bit 2 */
+	unsigned int rtc_synchronized :1; /* Bit 3 */
+	unsigned int rtc_initialized :1; /* Bit 4 */
+	unsigned int error_code_before_reset :1; /* Bit 5 */
+	unsigned int :1; /* Bit 6 */
+	unsigned int :1; /* Bit 7 */
+	unsigned int :1; /* Bit 8 */
+	unsigned int :1; /* Bit 9 */
+	unsigned int :1; /* Bit 10 */
+	unsigned int :1; /* Bit 11 */
+	unsigned int :1; /* Bit 12 */
+	unsigned int :1; /* Bit 13 */
+	unsigned int :1; /* Bit 14 */
+	unsigned int :1; /* Bit 15 */
+	unsigned int rtc_oszillator_error :1; /* Bit 16 */
+	unsigned int :1; /* Bit 17 */
+	unsigned int :1; /* Bit 18 */
+	unsigned int :1; /* Bit 19 */
+	unsigned int :1; /* Bit 20 */
+	unsigned int :1; /* Bit 21 */
+	unsigned int :1; /* Bit 22 */
+	unsigned int :1; /* Bit 23 */
+	unsigned int :1; /* Bit 24 */
+	unsigned int :1; /* Bit 25 */
+	unsigned int :1; /* Bit 26 */
+	unsigned int :1; /* Bit 27 */
+	unsigned int :1; /* Bit 28 */
+	unsigned int :1; /* Bit 29 */
+	unsigned int :1; /* Bit 30 */
+	unsigned int :1; /* Bit 31 */
+}
+volatile obc_status_t;
+
+obc_status_t obc_status;
+
+void taskDISABLE_INTERRUPTS() {
+	// in peg here is some ASM inline code called from RTOS
+	__disable_irq();
+}
+
+void taskENABLE_INTERRUPTS() {
+	// in peg here is some ASM inline code called from RTOS
+	__enable_irq();
+}
+
+#define EXTENDED_DEBUG_MESSAGES true
+
+volatile uint32_t rtc_epoch_time;
+
+#define RTC_AUX ((uint32_t *) 0x40024058)
+
+void RTC_IRQHandler(void)
+{
+	//LPC_TIM0->TC = 0; // Synchronize ms-timer to RTC seconds
+
+	Chip_RTC_ClearIntPending(LPC_RTC, RTC_INT_COUNTER_INCREASE);
+	Chip_RTC_ClearIntPending(LPC_RTC, RTC_INT_ALARM);
+
+	rtc_epoch_time++; /* increment QB50 s epoch variable and calculate UTC time */
+
+	/* Do powersave modes or other things here */
+	/*if (obc_status.obc_powersave)
+	{
+		// Reset watchdog regularly if OBC is in powersave
+		WDT_Feed();
+	}*/
+}
+
+/*void rtc_set_time(RTC_TIME_Type * etime)
+{
+	RTC_TIME_Type tim;
+
+	if (obc_status.rtc_initialized == 0)
+	{
+		return;
+	}
+
+	if (etime == NULL)
+	{
+		tim.SEC = 0;
+		tim.MIN = 36;
+		tim.HOUR = 16;
+		tim.DOM = 1;
+		tim.DOW = 1;
+		tim.DOY = 29;
+		tim.MONTH = 1;
+		tim.YEAR = 2016;
+
+		RTC_SetFullTime(LPC_RTC, &tim);
+	}
+	else
+	{
+		RTC_SetFullTime(LPC_RTC, etime);
+	}
+
+	rtc_backup_reg_reset(1); // optional
+}*/
+
+
+struct tm * gmtime_wrapper(int32_t * corrected_time)
+{
+	return gmtime((uint32_t *)corrected_time);
+}
+
+void rtc_correct_by_offset(int32_t offset_in_seconds)
+{
+	struct tm now;
+	RTC_TIME_T rtc_tim;
+	volatile uint32_t corrected_time;
+
+	if (obc_status.rtc_initialized == 0)
+	{
+		return;
+	}
+
+	/* Current time */
+	Chip_RTC_GetFullTime(LPC_RTC, &rtc_tim);
+
+	now.tm_hour = rtc_tim.time[RTC_TIMETYPE_HOUR];
+	now.tm_min = rtc_tim.time[RTC_TIMETYPE_MINUTE];
+	now.tm_sec = rtc_tim.time[RTC_TIMETYPE_SECOND];
+	now.tm_mday = rtc_tim.time[RTC_TIMETYPE_DAYOFMONTH]; 	/* Day of month (1 - 31) */
+	now.tm_mon = rtc_tim.time[RTC_TIMETYPE_MONTH]- 1;	 	/* Months since January (0 -11)*/
+	now.tm_year = rtc_tim.time[RTC_TIMETYPE_MONTH] - 1900;   /* Years since 1900 */
+
+	corrected_time = ((uint32_t) mktime(&now)) + offset_in_seconds;
+
+	if (corrected_time > 2147483648U)
+	{
+		// Corrected time is out of range
+		return;
+	}
+
+	volatile struct tm *t = gmtime_wrapper((int32_t *) &corrected_time);
+
+	rtc_tim.time[RTC_TIMETYPE_HOUR] 		= t->tm_hour;
+	rtc_tim.time[RTC_TIMETYPE_MINUTE] 		= t->tm_min;
+	rtc_tim.time[RTC_TIMETYPE_SECOND] 		= t->tm_sec;
+	rtc_tim.time[RTC_TIMETYPE_DAYOFMONTH] 	= t->tm_mday;
+	rtc_tim.time[RTC_TIMETYPE_MONTH]   		= t->tm_mon + 1; 		// RTC months from 1 - 12
+	rtc_tim.time[RTC_TIMETYPE_YEAR]    		= t->tm_year + 1900; 	// RTC years with 4 digits (YYYY)
+
+	Chip_RTC_SetFullTime(LPC_RTC, &rtc_tim);
+	rtc_calculate_epoch_time();
+	return;
+}
+
+BaseType_t rtc_init(void)
+{
+	RTC_TIME_T tim;
+
+	Chip_RTC_Init(LPC_RTC);
+
+	if (*RTC_AUX & RTC_AUX_RTC_OSCF)
+	{
+		/* RTC oszillator is not running*/
+		obc_status.rtc_oszillator_error = 1;
+#if EXTENDED_DEBUG_MESSAGES
+
+		printf("OBC: RTC: Oszillator error\n");
+#endif
+
+		obc_status.rtc_initialized = 0;
+		obc_status.rtc_synchronized = 0;
+		rtc_backup_reg_set(1, 0x00);	// RTC is definitely not in sync
+	}
+
+	/* Init Timer 1 before RTC enable */			// TODO module inits and sequence to be determined ....
+	//timer0_init();
+
+	/* Check RTC reset */
+	if (rtc_check_if_reset())
+	{
+		/* RTC module has been reset, time and data invalid */
+
+#if EXTENDED_DEBUG_MESSAGES
+		printf("OBC: RTC was reset\n", 0);
+#endif
+
+		/* Set to default values */
+		tim.time[RTC_TIMETYPE_SECOND] = 0;
+		tim.time[RTC_TIMETYPE_MINUTE] = 0;
+		tim.time[RTC_TIMETYPE_HOUR] = 0;
+		tim.time[RTC_TIMETYPE_DAYOFMONTH] = 1;
+		tim.time[RTC_TIMETYPE_DAYOFWEEK] = 1;		// ?? stimmt das hier wirklich ??
+		tim.time[RTC_TIMETYPE_DAYOFYEAR] = 1;
+		tim.time[RTC_TIMETYPE_MONTH] = 1;
+		tim.time[RTC_TIMETYPE_YEAR] = 2015;
+
+		Chip_RTC_SetFullTime(LPC_RTC, &tim);
+		rtc_backup_reg_reset(1);
+		rtc_backup_reg_set(1, 0x00);	// RTC is definitely not in sync
+		obc_status.rtc_synchronized = 0;
+	}
+	else
+	{
+#if EXTENDED_DEBUG_MESSAGES
+		printf("OBC: RTC was running\n");
+		printf("OBC: RTC: Time: %ld\n", rtc_get_time());
+		printf("OBC: RTC: Date: %ld\n", rtc_get_date());
+
+#endif
+
+		/* RTC was running - check if time is correct */
+		uint8_t rval = 0x00;
+		rtc_backup_reg_read(1, &rval);
+		if (rval == RTC_SYNCHRONIZED)
+		{
+			// RTC was running and a previous synchronization was successful -> time is valid
+			obc_status.rtc_synchronized = 1;
+#if EXTENDED_DEBUG_MESSAGES
+
+			printf("OBC: RTC is synchronized\n", 0);
+#endif
+
+		}
+		else
+		{
+			// RTC was running, but time was out of sync already
+			obc_status.rtc_synchronized = 0;
+#if EXTENDED_DEBUG_MESSAGES
+
+			printf("OBC: RTC is NOT synchronized\n", 0);
+#endif
+
+		}
+
+		/* Restore last error code from RTC register */
+		//obc_status.error_code_before_reset = error_code_get();		//TODO
+	}
+
+	rtc_calculate_epoch_time();
+
+	Chip_RTC_CntIncrIntConfig(LPC_RTC, RTC_TIMETYPE_SECOND, ENABLE);
+	NVIC_SetPriority(RTC_IRQn, RTC_INTERRUPT_PRIORITY);
+	NVIC_EnableIRQ(RTC_IRQn); /* Enable interrupt */
+
+	Chip_RTC_Enable(LPC_RTC, ENABLE);
+
+	obc_status.rtc_initialized = 1;
+	return DONE;
+}
+
+void rtc_calculate_epoch_time(void)
+{
+	struct tm start, now;
+	RTC_TIME_T rtc_tim;
+	rtc_epoch_time = 0;
+
+	/* 01.01.2000, 00:00:00 */
+	start.tm_hour = 0;
+	start.tm_min = 0;
+	start.tm_sec = 0;
+	start.tm_mday = 1; /* Day of month (1 - 31) */
+	start.tm_mon = 0; /* Months since January (0 -11)*/
+	start.tm_year = 100; /* Years since 1900 */
+
+	/* Current time */
+
+	Chip_RTC_GetFullTime(LPC_RTC, &rtc_tim);
+
+	now.tm_hour = rtc_tim.time[RTC_TIMETYPE_HOUR];
+	now.tm_min = rtc_tim.time[RTC_TIMETYPE_MINUTE];
+	now.tm_sec = rtc_tim.time[RTC_TIMETYPE_SECOND];
+	now.tm_mday = rtc_tim.time[RTC_TIMETYPE_DAYOFMONTH]; /* Day of month (1 - 31) */
+	now.tm_mon = rtc_tim.time[RTC_TIMETYPE_MONTH] - 1; /* Months since January (0 -11)*/
+	now.tm_year = rtc_tim.time[RTC_TIMETYPE_YEAR] - 1900; /* Years since 1900 */
+
+	rtc_epoch_time = (uint32_t) difftime(mktime(&now), mktime(&start));
+	return;
+}
+
+void rtc_get_val(RTC_TIME_T *tim)
+{
+	Chip_RTC_GetFullTime(LPC_RTC, tim);
+}
+
+uint32_t rtc_get_time(void)
+{
+	RTC_TIME_T tim;
+	Chip_RTC_GetFullTime(LPC_RTC, &tim);
+
+	// TODO: tim0 is not used for ms counting yet.....
+	return (0 + tim.time[RTC_TIMETYPE_SECOND] * 1000 + tim.time[RTC_TIMETYPE_MINUTE] * 100000 + tim.time[RTC_TIMETYPE_HOUR] * 10000000);
+	//return ((LPC_TIM0->TC) + tim.SEC * 1000 + tim.MIN * 100000 + tim.HOUR * 10000000);
+}
+
+uint32_t rtc_get_date(void)
+{
+	/* Returns the current RTC date according to UTC.
+	 * Parameters: 	none
+	 * Return value: date
+	 */
+	RTC_TIME_T tim;
+	Chip_RTC_GetFullTime(LPC_RTC, &tim);
+
+	return (tim.time[RTC_TIMETYPE_DAYOFMONTH] + tim.time[RTC_TIMETYPE_MONTH] * 100 + (tim.time[RTC_TIMETYPE_YEAR] - 2000) * 10000);
+}
+
+uint32_t rtc_get_epoch_time(void)
+{
+	return rtc_epoch_time;
+}
+
+//
+// copied from lpc17xx_rtc.c and adapted to current lpc_chip_175x_6x library
+// @version		3.0
+// @date		18. June. 2010
+/*********************************************************************//**
+ * @brief 		Read value from General purpose registers
+ * @param[in]	RTCx	RTC peripheral selected, should be LPC_RTC
+ * @param[in]	Channel General purpose registers Channel number,
+ * 				should be in range from 0 to 4.
+ * @return 		Read Value
+ * Note: These General purpose registers can be used to store important
+ * information when the main power supply is off. The value in these
+ * registers is not affected by chip reset.
+ **********************************************************************/
+uint32_t RTC_ReadGPREG(LPC_RTC_T *RTCx, uint8_t Channel)
+{
+	uint32_t *preg;
+	uint32_t value;
+
+//	CHECK_PARAM(PARAM_RTCx(RTCx));
+//	CHECK_PARAM(PARAM_RTC_GPREG_CH(Channel));
+
+	preg = (uint32_t *) &(RTCx->GPREG);
+	preg += Channel;
+	value = *preg;
+	return (value);
+}
+
+/*********************************************************************//**
+ * @brief 		Write value to General purpose registers
+ * @param[in]	RTCx	RTC peripheral selected, should be LPC_RTC
+ * @param[in]	Channel General purpose registers Channel number,
+ * 				should be in range from 0 to 4.
+ * @param[in]	Value Value to write
+ * @return 		None
+ * Note: These General purpose registers can be used to store important
+ * information when the main power supply is off. The value in these
+ * registers is not affected by chip reset.
+ **********************************************************************/
+void RTC_WriteGPREG(LPC_RTC_T *RTCx, uint8_t Channel, uint32_t Value)
+{
+	uint32_t *preg;
+
+//	CHECK_PARAM(PARAM_RTCx(RTCx));
+//	CHECK_PARAM(PARAM_RTC_GPREG_CH(Channel));
+
+	preg = (uint32_t *) &(RTCx->GPREG);
+	preg += Channel;
+	*preg = Value;
+}
+
+
+
+RetVal rtc_backup_reg_set(uint8_t id, uint8_t val)
+{
+	/* Writes one byte to the RTC's buffered registers. The register number is specified with the parameter id.
+	 * Parameters: 	uint8_t id - Register number to write
+	 * 				uint8_t val - Value written to the register
+	 * Return value: SUCCESS/ERROR
+	 */
+
+	uint8_t regs[20] =
+	{ };
+
+	if (id >= 19)
+	{
+		/* Register does not exist or is protected. */
+		return FAILED;
+	}
+
+	/* Prevent all other tasks and interrupts from altering the register contents */
+	taskDISABLE_INTERRUPTS();
+
+	/* Read all registers */
+	*((uint32_t *) &regs[0]) = RTC_ReadGPREG(LPC_RTC, 0);
+	*((uint32_t *) &regs[4]) = RTC_ReadGPREG(LPC_RTC, 1);
+	*((uint32_t *) &regs[8]) = RTC_ReadGPREG(LPC_RTC, 2);
+	*((uint32_t *) &regs[12]) = RTC_ReadGPREG(LPC_RTC, 3);
+	*((uint32_t *) &regs[16]) = RTC_ReadGPREG(LPC_RTC, 4);
+
+	/* Set given value */
+	regs[id] = val;
+
+	/* Calculate and store new checksum */
+	regs[19] = rtc_checksum_calc(&regs[0]);
+
+	/* Store values */
+	RTC_WriteGPREG(LPC_RTC, 0, *((uint32_t *) (&regs[0])));
+	RTC_WriteGPREG(LPC_RTC, 1, *((uint32_t *) (&regs[4])));
+	RTC_WriteGPREG(LPC_RTC, 2, *((uint32_t *) (&regs[8])));
+	RTC_WriteGPREG(LPC_RTC, 3, *((uint32_t *) (&regs[12])));
+	RTC_WriteGPREG(LPC_RTC, 4, *((uint32_t *) (&regs[16])));
+
+	taskENABLE_INTERRUPTS();
+
+	return DONE;
+}
+
+RetVal rtc_backup_reg_reset(uint8_t go)
+{
+	/* Resets the backup registers and calculates the checksum
+	 *
+	 */
+
+	if (go == 0)
+	{
+		return FAILED;
+	}
+
+	uint8_t regs[20] =
+	{ };
+
+	/* Prevent all other tasks and interrupts from altering the register contents */
+	taskDISABLE_INTERRUPTS();
+
+	/* Calculate and store new checksum */
+	regs[19] = rtc_checksum_calc(&regs[0]);
+
+	/* Store values */
+	RTC_WriteGPREG(LPC_RTC, 0, *((uint32_t *) (&regs[0])));
+	RTC_WriteGPREG(LPC_RTC, 1, *((uint32_t *) (&regs[4])));
+	RTC_WriteGPREG(LPC_RTC, 2, *((uint32_t *) (&regs[8])));
+	RTC_WriteGPREG(LPC_RTC, 3, *((uint32_t *) (&regs[12])));
+	RTC_WriteGPREG(LPC_RTC, 4, *((uint32_t *) (&regs[16])));
+
+	taskENABLE_INTERRUPTS();
+
+	return DONE;
+}
+
+RetVal rtc_backup_reg_read(uint8_t id, uint8_t * val)
+{
+	/* Reads one byte from the RTC's buffered registers. The register number is specified with the parameter id.
+	 * Parameters: 	uint8_t id - Register number to read from
+	 * 				uint8_t * - pointer where value shall be stored
+	 * Return value: 0 in case of success, else (wrong checksum) != 0
+	 * ID
+	 */
+
+	/* Read all registers */
+
+	uint8_t cs;
+	uint8_t regs[20] =
+	{ };
+
+	if (id > 19)
+	{
+		/* Register does not exist */
+		return FAILED;
+	}
+
+	taskDISABLE_INTERRUPTS();
+
+	*((uint32_t *) &regs[0]) = RTC_ReadGPREG(LPC_RTC, 0);
+	*((uint32_t *) &regs[4]) = RTC_ReadGPREG(LPC_RTC, 1);
+	*((uint32_t *) &regs[8]) = RTC_ReadGPREG(LPC_RTC, 2);
+	*((uint32_t *) &regs[12]) = RTC_ReadGPREG(LPC_RTC, 3);
+	*((uint32_t *) &regs[16]) = RTC_ReadGPREG(LPC_RTC, 4);
+
+	/* Calculate checksum */
+	cs = rtc_checksum_calc(&regs[0]);
+
+	taskENABLE_INTERRUPTS();
+
+	/* Compare checksums */
+	if (cs != regs[19])
+	{
+		/* Checksum is not correct - values may be corrupted */
+		return FAILED;
+	}
+
+	*val = regs[id];
+
+	return DONE;
+}
+
+RetVal rtc_check_if_reset(void)
+{
+	/**
+	 * Check if the RTC module was reseted and therefore time and register values are invalid.
+	 */
+
+	uint8_t cs;
+	uint8_t regs[20] =
+	{ };
+
+	taskDISABLE_INTERRUPTS();
+
+	*((uint32_t *) &regs[0]) = RTC_ReadGPREG(LPC_RTC, 0);
+	*((uint32_t *) &regs[4]) = RTC_ReadGPREG(LPC_RTC, 1);
+	*((uint32_t *) &regs[8]) = RTC_ReadGPREG(LPC_RTC, 2);
+	*((uint32_t *) &regs[12]) = RTC_ReadGPREG(LPC_RTC, 3);
+	*((uint32_t *) &regs[16]) = RTC_ReadGPREG(LPC_RTC, 4);
+
+	/* Calculate checksum */
+	cs = rtc_checksum_calc(&regs[0]);
+
+	taskENABLE_INTERRUPTS();
+
+	/* Compare checksums */
+	if (cs != regs[19])
+	{
+#if EXTENDED_DEBUG_MESSAGES
+		printf("OBC: RTC: Was reset.\n");
+#endif
+		/* Checksum is not correct - values may be corrupted */
+
+		return FAILED;
+	}
+
+	return DONE;
+}
+
+uint8_t rtc_checksum_calc(uint8_t *data)
+{
+	/* Add 1 to ensure 0 for all data entries gives a cs != 0 */
+	return (CRC8(data, 19) + 1);
+}

--- a/HardwareTests/src/mod/tim/obc_rtc.c
+++ b/HardwareTests/src/mod/tim/obc_rtc.c
@@ -5,6 +5,7 @@
 /* Other includes */
 #include "obc_rtc.h"
 #include "../crc/obc_checksums.h"
+#include "../cli/cli.h"
 
 typedef struct obc_status_s
 {
@@ -60,6 +61,14 @@ void taskENABLE_INTERRUPTS() {
 volatile uint32_t rtc_epoch_time;
 
 #define RTC_AUX ((uint32_t *) 0x40024058)
+
+
+void RtcGetTimeCmd(int argc, char *argv[]) {
+	printf("OBC: RTC: Time: %ld\n", rtc_get_time());
+	printf("OBC: RTC: Date: %ld\n", rtc_get_date());
+}
+
+
 
 void RTC_IRQHandler(void)
 {
@@ -157,7 +166,7 @@ void rtc_correct_by_offset(int32_t offset_in_seconds)
 	return;
 }
 
-BaseType_t rtc_init(void)
+void rtc_init(void)
 {
 	RTC_TIME_T tim;
 
@@ -243,14 +252,17 @@ BaseType_t rtc_init(void)
 
 	rtc_calculate_epoch_time();
 
-	Chip_RTC_CntIncrIntConfig(LPC_RTC, RTC_TIMETYPE_SECOND, ENABLE);
+	Chip_RTC_CntIncrIntConfig(LPC_RTC, RTC_AMR_CIIR_IMSEC,  ENABLE);
 	NVIC_SetPriority(RTC_IRQn, RTC_INTERRUPT_PRIORITY);
 	NVIC_EnableIRQ(RTC_IRQn); /* Enable interrupt */
 
 	Chip_RTC_Enable(LPC_RTC, ENABLE);
 
 	obc_status.rtc_initialized = 1;
-	return DONE;
+
+	RegisterCommand("getTim", RtcGetTimeCmd);
+
+	return;
 }
 
 void rtc_calculate_epoch_time(void)

--- a/HardwareTests/src/mod/tim/obc_rtc.h
+++ b/HardwareTests/src/mod/tim/obc_rtc.h
@@ -1,0 +1,58 @@
+#ifndef OBC_RTC_H
+#define OBC_RTC_H
+
+/* Standard includes */
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <Chip.h>
+/* FreeRTOS includes */
+//#include "FreeRTOS.h"
+//#include "task.h"
+//#include "queue.h"
+//#include "semphr.h"
+//
+///* Other includes */
+//#include "lpc17xx_timer.h"
+//#include "lpc17xx_rtc.h"
+//
+//#include "main.h"
+// From RTOS
+typedef long BaseType_t;
+
+#define configMAX_LIBRARY_INTERRUPT_PRIORITY    ( 5 )
+#define RTC_INTERRUPT_PRIORITY  (configMAX_LIBRARY_INTERRUPT_PRIORITY + 1)  /* RTC - highest priority after watchdog! */
+
+typedef enum
+{
+	DONE = 0, FAILED = !DONE
+} RetVal;
+
+
+#define RTC_SYNCHRONIZED 0xAB
+
+typedef struct rtc_status_s
+{
+	uint8_t rtc_synchronized;
+} rtc_status_t;
+
+BaseType_t rtc_init(void);
+
+void rtc_get_val(RTC_TIME_T *tim);
+uint32_t rtc_get_date(void);
+uint32_t rtc_get_time(void);
+uint64_t rtc_get_extended_time(void);
+void rtc_calculate_epoch_time(void);
+uint32_t rtc_get_epoch_time(void);
+//void rtc_set_time(RTC_TIME_Type * etime);
+void rtc_correct_by_offset(int32_t offset_in_seconds);
+
+RetVal rtc_check_if_reset(void);
+uint8_t rtc_checksum_calc(uint8_t *data);
+RetVal rtc_sync(RTC_TIME_T *tim);
+
+RetVal rtc_backup_reg_read(uint8_t id, uint8_t * val);
+RetVal rtc_backup_reg_set(uint8_t id, uint8_t val);
+RetVal rtc_backup_reg_reset(uint8_t go);
+
+#endif /* OBC_RTC_H */

--- a/HardwareTests/src/mod/tim/obc_rtc.h
+++ b/HardwareTests/src/mod/tim/obc_rtc.h
@@ -6,53 +6,13 @@
 #include <stdlib.h>
 
 #include <Chip.h>
-/* FreeRTOS includes */
-//#include "FreeRTOS.h"
-//#include "task.h"
-//#include "queue.h"
-//#include "semphr.h"
-//
-///* Other includes */
-//#include "lpc17xx_timer.h"
-//#include "lpc17xx_rtc.h"
-//
-//#include "main.h"
-// From RTOS
-//typedef long BaseType_t;
 
-#define configMAX_LIBRARY_INTERRUPT_PRIORITY    ( 5 )
-#define RTC_INTERRUPT_PRIORITY  (configMAX_LIBRARY_INTERRUPT_PRIORITY + 1)  /* RTC - highest priority after watchdog! */
+// Module Main API
+void RtcInit(void);
 
-typedef enum
-{
-	DONE = 0, FAILED = !DONE
-} RetVal;
+//  Module fuinctions API
+bool RtcIsGprChecksumOk(void);
 
 
-#define RTC_SYNCHRONIZED 0xAB
-
-typedef struct rtc_status_s
-{
-	uint8_t rtc_synchronized;
-} rtc_status_t;
-
-void rtc_init(void);
-
-void rtc_get_val(RTC_TIME_T *tim);
-uint32_t rtc_get_date(void);
-uint32_t rtc_get_time(void);
-uint64_t rtc_get_extended_time(void);
-void rtc_calculate_epoch_time(void);
-uint32_t rtc_get_epoch_time(void);
-//void rtc_set_time(RTC_TIME_Type * etime);
-void rtc_correct_by_offset(int32_t offset_in_seconds);
-
-RetVal rtc_check_if_reset(void);
-uint8_t rtc_checksum_calc(uint8_t *data);
-RetVal rtc_sync(RTC_TIME_T *tim);
-
-RetVal rtc_backup_reg_read(uint8_t id, uint8_t * val);
-RetVal rtc_backup_reg_set(uint8_t id, uint8_t val);
-RetVal rtc_backup_reg_reset(uint8_t go);
 
 #endif /* OBC_RTC_H */

--- a/HardwareTests/src/mod/tim/obc_rtc.h
+++ b/HardwareTests/src/mod/tim/obc_rtc.h
@@ -13,7 +13,7 @@ void RtcInit(void);
 //  Module functions API
 bool RtcIsGprChecksumOk(void);
 void RtcSetDate(uint16_t year, uint8_t month, uint8_t dayOfMonth);
-void RtcSetTime(uint8_t hours, uint8_t minutes, uint8_t seconds);
+void RtcSetTime(uint8_t hours, uint8_t minutes, uint8_t seconds, bool synchronized);
 
 
 #endif /* OBC_RTC_H */

--- a/HardwareTests/src/mod/tim/obc_rtc.h
+++ b/HardwareTests/src/mod/tim/obc_rtc.h
@@ -9,6 +9,7 @@
 
 // Module Main API
 void RtcInit(void);
+void RtcMain(void);
 
 //  Module functions API
 bool RtcIsGprChecksumOk(void);

--- a/HardwareTests/src/mod/tim/obc_rtc.h
+++ b/HardwareTests/src/mod/tim/obc_rtc.h
@@ -18,7 +18,7 @@
 //
 //#include "main.h"
 // From RTOS
-typedef long BaseType_t;
+//typedef long BaseType_t;
 
 #define configMAX_LIBRARY_INTERRUPT_PRIORITY    ( 5 )
 #define RTC_INTERRUPT_PRIORITY  (configMAX_LIBRARY_INTERRUPT_PRIORITY + 1)  /* RTC - highest priority after watchdog! */
@@ -36,7 +36,7 @@ typedef struct rtc_status_s
 	uint8_t rtc_synchronized;
 } rtc_status_t;
 
-BaseType_t rtc_init(void);
+void rtc_init(void);
 
 void rtc_get_val(RTC_TIME_T *tim);
 uint32_t rtc_get_date(void);

--- a/HardwareTests/src/mod/tim/obc_rtc.h
+++ b/HardwareTests/src/mod/tim/obc_rtc.h
@@ -10,9 +10,10 @@
 // Module Main API
 void RtcInit(void);
 
-//  Module fuinctions API
+//  Module functions API
 bool RtcIsGprChecksumOk(void);
-
+void RtcSetDate(uint16_t year, uint8_t month, uint8_t dayOfMonth);
+void RtcSetTime(uint8_t hours, uint8_t minutes, uint8_t seconds);
 
 
 #endif /* OBC_RTC_H */

--- a/HardwareTests/src/mod/tim/timer.h
+++ b/HardwareTests/src/mod/tim/timer.h
@@ -12,12 +12,15 @@
 
 #include <stdbool.h>
 
+// Module main API
 void TimInit();						    // Module Init called once prior mainloop
 bool TimMain();							// Module routine participating each mainloop.
 
+// Module function API
 void TimBlockMs(uint8_t ms);			// This really blocks. So use carefully.
 bool TimWaitForFalseMs(volatile bool *flag, uint8_t ms);		// This really blocks. So use carefully.
 
-
+// Module global variables
+extern uint32_t	secondsAfterReset;
 
 #endif /* MOD_TIM_TIMER_H_ */


### PR DESCRIPTION
- RTC after reset checks its 20 GPR bytes for checksum error -> if error it gets initializes with 'a', 'b', .... 
- RTC stores its own Status in GPR byte[0] 
- GetTime command shows RTC Status, Date and Time.
- SetDate/SetTime commands available
- There is a ms timer now (as we had in PEG).TC counting from 0 .. 999. every interupt a secondAfterReset register is incremented.
- If running for more than 2days (without new setting date or time) on day change the RTC seconds (XTAL2) are compared to the TIMER1 ms (XTAL1). (prepared for getting calibration values)
- no persistence (other than GPR bytes at this moment.
- no epochtime /mission time concept yet

