### PR TITLE
Feature/sidepanel supply

### DIFF
--- a/HardwareTests/src/hw_obc/board.c
+++ b/HardwareTests/src/hw_obc/board.c
@@ -39,6 +39,8 @@
 #define RBF_PIN									21
 #define RBF_PORT								0
 
+#define STACIE_A_IO1_PIN						21
+#define STACIE_A_IO1_PORT						1
 
 
 void SwitchVccFfgDCmd(int argc, char *argv[]);
@@ -132,6 +134,10 @@ void ObcClimbBoardInit() {
 	ObcSpSupplySet(2, true);
 	ObcSpSupplySet(3, true);
 	ObcSpSupplySet(4, true);
+
+	// Stacie A GPIO -> set as output for rad-tests
+	Chip_GPIO_WriteDirBit(LPC_GPIO, STACIE_A_IO1_PORT, STACIE_A_IO1_PIN, true);
+
 
 	// Feed watchdog
 	ObcWdtFeedSet(true);
@@ -254,8 +260,9 @@ char ObcGetSupplyRail(){
 	{
 		return 'C';
 	}
-}
 
+}
+/* Returns true if the RBF is inserted */
 bool ObcGetRbfIsInserted(){
 
 	if (Chip_GPIO_ReadPortBit(LPC_GPIO, RBF_PORT, RBF_PIN))
@@ -265,6 +272,14 @@ bool ObcGetRbfIsInserted(){
 	else
 	{
 		return false;
+	}
+}
+
+/* Sets the state of the STACIE A IO-X PIN */
+void ObcLedStacieAIo(uint8_t io, bool On)
+{
+	if (io == 1) {
+		Chip_GPIO_WritePortBit(LPC_GPIO, STACIE_A_IO1_PORT, STACIE_A_IO1_PIN, On);
 	}
 }
 

--- a/HardwareTests/src/hw_obc/board.c
+++ b/HardwareTests/src/hw_obc/board.c
@@ -24,6 +24,16 @@
 #define DEBUG_SELECT_GPIO_PORT_NUM               0
 #define DEBUG_SELECT_GPIO_BIT_NUM                5
 
+#define SP1_VCC_EN_PIN							28
+#define SP1_VCC_EN_PORT							1
+#define SP2_VCC_EN_PIN							7
+#define SP2_VCC_EN_PORT							2
+#define SP3_VCC_EN_PIN							15
+#define SP3_VCC_EN_PORT							1
+#define SP4_VCC_EN_PIN							22
+#define SP4_VCC_EN_PORT							1
+
+
 
 void SwitchVccFfgDCmd(int argc, char *argv[]);
 /* Pin muxing configuration */
@@ -101,6 +111,23 @@ void ObcClimbBoardInit() {
 
 	// Init I2c bus for Onboard devices (3xEEProm, 1xTemp, 1x FRAM)
 	InitOnboardI2C(ONBOARD_I2C);
+
+	// Sidepanel supply swiches (outputs)
+	Chip_GPIO_WriteDirBit(LPC_GPIO, SP1_VCC_EN_PORT, SP1_VCC_EN_PIN, true);
+	Chip_GPIO_WriteDirBit(LPC_GPIO, SP2_VCC_EN_PORT, SP2_VCC_EN_PIN, true);
+	Chip_GPIO_WriteDirBit(LPC_GPIO, SP3_VCC_EN_PORT, SP3_VCC_EN_PIN, true);
+	Chip_GPIO_WriteDirBit(LPC_GPIO, SP4_VCC_EN_PORT, SP4_VCC_EN_PIN, true);
+
+	// Enable supply to all sidepanels
+	ObcSpSupplySet(1, true);
+	ObcSpSupplySet(2, true);
+	ObcSpSupplySet(3, true);
+	ObcSpSupplySet(4, true);
+
+	// Feed watchdog
+	ObcWdtFeedSet(true);
+	ObcWdtFeedSet(false);
+
 
 	//Chip_GPIO_SetPinState(LPC_GPIO, 0, 26, false);
 }
@@ -181,5 +208,29 @@ uint8_t ObcGetI2CAddrForMemoryDeviceName(char* name) {
     }
 
     return 0;
+}
+
+/* Sets the state of the specified supply panel switch to on or off (logic low on pin turns on output) */
+void ObcSpSupplySet(uint8_t sp, bool On)
+{
+	/* There is only one LED */
+	if (sp == 1) {
+		Chip_GPIO_WritePortBit(LPC_GPIO, SP1_VCC_EN_PORT, SP1_VCC_EN_PIN, !On);
+	}
+	else if (sp == 2) {
+		Chip_GPIO_WritePortBit(LPC_GPIO, SP2_VCC_EN_PORT, SP2_VCC_EN_PIN, !On);
+	}
+	else if (sp == 3) {
+		Chip_GPIO_WritePortBit(LPC_GPIO, SP3_VCC_EN_PORT, SP3_VCC_EN_PIN, !On);
+	}
+	else if (sp == 4) {
+		Chip_GPIO_WritePortBit(LPC_GPIO, SP4_VCC_EN_PORT, SP4_VCC_EN_PIN, !On);
+	}
+}
+
+/* Sets the state of the watchdog feed pin to on/off */
+void ObcWdtFeedSet(bool On)
+{
+	Chip_GPIO_WritePortBit(LPC_GPIO, LED_GREEN_WD_GPIO_PORT_NUM, LED_GREEN_WD_GPIO_BIT_NUM, On);
 }
 

--- a/HardwareTests/src/hw_obc/board.c
+++ b/HardwareTests/src/hw_obc/board.c
@@ -33,6 +33,12 @@
 #define SP4_VCC_EN_PIN							22
 #define SP4_VCC_EN_PORT							1
 
+#define SUPPLY_RAIL_PIN 						25
+#define SUPPLY_RAIL_PORT 						3
+
+#define RBF_PIN									21
+#define RBF_PORT								0
+
 
 
 void SwitchVccFfgDCmd(int argc, char *argv[]);
@@ -105,6 +111,9 @@ void ObcClimbBoardInit() {
 	Chip_GPIO_WriteDirBit(LPC_GPIO, DEBUG_SELECT_GPIO_PORT_NUM, DEBUG_SELECT_GPIO_BIT_NUM, false);
 	Chip_GPIO_WriteDirBit(LPC_GPIO, BOOT_SELECT_GPIO_PORT_NUM, BOOT_SELECT_GPIO_BIT_NUM, false);
 	Chip_GPIO_WriteDirBit(LPC_GPIO, 0, 30, false);
+
+	// Supply rail status input
+	Chip_GPIO_WriteDirBit(LPC_GPIO, SUPPLY_RAIL_PORT, SUPPLY_RAIL_PIN, false);
 
 	// UART for comand line interface init
 	CliInitUart(LPC_UART2, UART2_IRQn);		// We use SP - B (same side as JTAG connector) as Debug UART.);
@@ -233,4 +242,31 @@ void ObcWdtFeedSet(bool On)
 {
 	Chip_GPIO_WritePortBit(LPC_GPIO, LED_GREEN_WD_GPIO_PORT_NUM, LED_GREEN_WD_GPIO_BIT_NUM, On);
 }
+
+/* Reads the status of the active supply rail */
+char ObcGetSupplyRail(){
+
+	if (Chip_GPIO_ReadPortBit(LPC_GPIO, SUPPLY_RAIL_PORT, SUPPLY_RAIL_PIN))
+	{
+		return 'A';
+	}
+	else
+	{
+		return 'C';
+	}
+}
+
+bool ObcGetRbfIsInserted(){
+
+	if (Chip_GPIO_ReadPortBit(LPC_GPIO, RBF_PORT, RBF_PIN))
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+
 

--- a/HardwareTests/src/hw_obc/obc_board.h
+++ b/HardwareTests/src/hw_obc/obc_board.h
@@ -57,6 +57,7 @@ void ObcSpSupplySet(uint8_t sp, bool On);
 void ObcWdtFeedSet(bool On);
 char ObcGetSupplyRail();
 bool ObcGetRbfIsInserted();
+void ObcLedStacieAIo(uint8_t io, bool On);
 
 uint8_t ObcGetI2CAddrForMemoryDeviceName(char* name);
 

--- a/HardwareTests/src/hw_obc/obc_board.h
+++ b/HardwareTests/src/hw_obc/obc_board.h
@@ -55,6 +55,8 @@ void ObcLedSet(uint8_t ledNr,  bool On);
 bool ObcLedTest(uint8_t ledNr);
 void ObcSpSupplySet(uint8_t sp, bool On);
 void ObcWdtFeedSet(bool On);
+char ObcGetSupplyRail();
+bool ObcGetRbfIsInserted();
 
 uint8_t ObcGetI2CAddrForMemoryDeviceName(char* name);
 

--- a/HardwareTests/src/hw_obc/obc_board.h
+++ b/HardwareTests/src/hw_obc/obc_board.h
@@ -53,6 +53,8 @@ char* ObcGetBootmodeStr();
 void ObcLedToggle(uint8_t ledNr);
 void ObcLedSet(uint8_t ledNr,  bool On);
 bool ObcLedTest(uint8_t ledNr);
+void ObcSpSupplySet(uint8_t sp, bool On);
+void ObcWdtFeedSet(bool On);
 
 uint8_t ObcGetI2CAddrForMemoryDeviceName(char* name);
 

--- a/HardwareTests/src/mod/rad/radiation_test.c
+++ b/HardwareTests/src/mod/rad/radiation_test.c
@@ -13,10 +13,11 @@
 #include "../tim/obc_rtc.h"
 #include "../cli/cli.h"
 #include "../main.h"		// for Flash signature
+#include "../../hw_obc/obc_board.h" 		// For watchdog feed pin
 
 #include "radtst_memory.h"
 
-#define RADTST_SEQ_SENSOR_REPORT_SECONDS				5			// Send all sensor values every 5 seconds
+#define RADTST_SEQ_SENSOR_REPORT_SECONDS				4			// Send all sensor values every 5 seconds
 
 #define RADTST_SEQ_LOGBERRY_WATCHDOG_SECONDS			60			// Send Watchdog message every 60 seconds
 #define RADTST_SEQ_REPORTLINE_SECONDS				   300			// print out a report line with all check and error counters.
@@ -218,7 +219,10 @@ void RadTstMain(void) {
 		RadTstLogberryWatchdog();
 	}
 	if ((radtstTicks % (RADTST_SEQ_SENSOR_REPORT_SECONDS * 1000 / TIM_MAIN_TICK_MS))  == 0) {
+		// Transmit sensor values and reset onboard watchdog every 4 seconds
+		ObcWdtFeedSet(true);
 		read_transmit_sensors();
+		ObcWdtFeedSet(false);
 	}
 	if ((radtstTicks % (RADTST_SEQ_REPORTLINE_SECONDS * 1000 / TIM_MAIN_TICK_MS))  == 0) {
 		RadTstPrintReportLine();

--- a/HardwareTests/src/mod/rad/radiation_test.c
+++ b/HardwareTests/src/mod/rad/radiation_test.c
@@ -216,7 +216,9 @@ void RadTstResetReadExpectations() {
 void RadTstMain(void) {
 	radtstTicks++;
 	if ((radtstTicks % (RADTST_SEQ_LOGBERRY_WATCHDOG_SECONDS * 1000 / TIM_MAIN_TICK_MS))  == 0) {
+		ObcLedStacieAIo(1,true);
 		RadTstLogberryWatchdog();
+		ObcLedStacieAIo(1,false);
 	}
 	if ((radtstTicks % (RADTST_SEQ_SENSOR_REPORT_SECONDS * 1000 / TIM_MAIN_TICK_MS))  == 0) {
 		// Transmit sensor values and reset onboard watchdog every 4 seconds

--- a/HardwareTests/src/mod/sen/obc_adc.c
+++ b/HardwareTests/src/mod/sen/obc_adc.c
@@ -99,6 +99,7 @@ void AdcInit()
 
 void read_transmit_sensors()
 {
+
 	uint16_t adc_val; // = ADC_ChannelGetData(LPC_ADC, ADC_SUPPLY_CURRENT_CH);
 	Chip_ADC_ReadValue(LPC_ADC, ADC_SUPPLY_CURRENT_CH, &adc_val);
 
@@ -122,58 +123,3 @@ void read_transmit_sensors()
 
 	printf("RBF: %d, Supply-R: %c, BL: %s\n", ObcGetRbfIsInserted(),  ObcGetSupplyRail(), ObcGetBootmodeStr());
 }
-
-
-//bool rbf_check_inserted(void)
-//{
-//    if ((GPIO_ReadValue(RBF_PORT) & (1 << RBF_PIN)))
-//    {
-//    	/* Flight mode */
-//    	obc_status.rbf_inserted = 0;
-//    	return false;
-//    }
-//    else
-//    {
-//    	/* RBF inserted - ground mode */
-//    	obc_status.rbf_inserted = 1;
-//    	return true;
-//    }
-//}
-//
-//bool supply_rail_check(void)
-//{
-//    if ((GPIO_ReadValue(SUPPLY_RAIL_PORT) & (1 << SUPPLY_RAIL_PIN)))
-//    {
-//    	return false;
-//    }
-//    else
-//    {
-//    	return true;
-//    }
-//}
-
-//void bl_init()
-//{
-//	 /* Configure P0[29] and P0[30] because 29 and 30 are a USB Pair normally */
-//    xPinConfig.Pinnum = BL_SEL1_PIN;
-//    xPinConfig.Portnum = BL_SEL1_PORT;
-//    PINSEL_ConfigPin(&(xPinConfig));
-//    GPIO_SetDir(BL_SEL1_PORT, (1 << BL_SEL1_PIN), 0); //  input
-//
-//    xPinConfig.Pinnum = 30;
-//    xPinConfig.Portnum = 0;
-//    PINSEL_ConfigPin(&(xPinConfig));
-//    GPIO_SetDir(0, (1 << 30), 0); //  input
-//}
-
-//bool bl_sel_pin_check(void)
-//{
-//    if ((GPIO_ReadValue(BL_SEL1_PORT) & (1 << BL_SEL1_PIN)))
-//    {
-//    	return false;
-//    }
-//    else
-//    {
-//    	return true;
-//    }
-//}

--- a/HardwareTests/src/mod/sen/obc_adc.c
+++ b/HardwareTests/src/mod/sen/obc_adc.c
@@ -3,6 +3,7 @@
 
 #include "..\cli\cli.h"
 #include "..\tim\obc_rtc.h"
+#include "..\..\hw_obc\obc_board.h"
 
 #define ADC_SUPPLY_CURRENT_PIN 		23 //ok
 #define ADC_SUPPLY_CURRENT_PORT 	0 //ok
@@ -114,15 +115,12 @@ void read_transmit_sensors()
 	val = 25 + (adc_val * (3.3/4096) - 0.75) / 0.01;
 	printf("TMP-AN: %.3f C;", val);
 
+
+
 	printf("RTC: %d, %d \n", rtc_get_time(), rtc_get_date());
 
-//	rbf_check_inserted();
-//	char c;
-//	if(supply_rail_check() == 0)
-//		c = 'A';
-//	else
-//		c = 'C';
-//	debug_sprintf("RBF: %d, Supply-R: %c, BL: %d\n", obc_status.rbf_inserted, c, bl_sel_pin_check());
+
+	printf("RBF: %d, Supply-R: %c, BL: %s\n", ObcGetRbfIsInserted(),  ObcGetSupplyRail(), ObcGetBootmodeStr());
 }
 
 


### PR DESCRIPTION
Implemented more GPIO functionality:
- Sidepanel supply enable pins
- RBF pin input and readout
- Supply rail input and readout

The new values are transmitted automatically similar to other sensor values. Additionally the onboard WDT is feed regularly.

Fixes issue #45.
